### PR TITLE
Fix error on Examples Foundation Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for **SwifterSwift**. Also see the [releases](https://github.com/S
   - `localized(comment:)` now supports all parameters provided by `NSLocalizedString(tableName:bundle:value:comment:)`. [#1217](https://github.com/SwifterSwift/SwifterSwift/pull/1217) by [Shiki Suen](https://github.com/ShikiSuen)
 
 ### Fixed
+- **Examples** : Added "import Foundation" to Foundation Extension Playground page for Date() extension to work properly on Mac
 
 ### Deprecated
 


### PR DESCRIPTION
Add "import Foundation"

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ X] New extensions are written in Swift 5.6.
- [ X] New extensions support iOS 12.0+ / tvOS 12.0+ / macOS 10.13+ / watchOS 4.0+, or use `@available` if not.
- [ X] I have added tests for new extensions, and they passed.
- [ X] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ X] All extensions are declared as **public**.
- [ X] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
